### PR TITLE
remove '/var/run/monit.pid' on startup

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,6 +6,7 @@ function exitColumnStore {
   /usr/bin/monit quit
 }
 
+rm -f /var/run/monit.pid
 rm -f /var/run/syslogd.pid
 rsyslogd
 


### PR DESCRIPTION
Closes #2 

If docker sends a `SIGKILL` before `monit` gets the chance to delete its PID file under `/var/run/monit.pid` the container cannot be started again.

To replicate start a `mariadb/columnstore` container and stop it with `docker stop -t 1 <container_name or container_id>` 

As a work-around the PID file can be deleted in the `docker-entrypoint.sh`, similar to `/var/run/syslogd.pid`